### PR TITLE
웹뷰에서 파일 다운로드시 파일 이름 끝에 세미콜론 붙는 문제 해결

### DIFF
--- a/presentation/src/main/java/com/foundy/presentation/view/webview/WebViewActivity.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/webview/WebViewActivity.kt
@@ -153,10 +153,12 @@ class WebViewActivity : AppCompatActivity() {
         lifecycleScope.launch {
             if (requestPermission()) {
                 val downloadRequest = DownloadManager.Request(Uri.parse(url)).apply {
+                    val fileName = URLUtil.guessFileName(url, contentDisposition, mimeType)
+
                     setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
                     setDestinationInExternalPublicDir(
                         Environment.DIRECTORY_DOWNLOADS,
-                        URLUtil.guessFileName(url, contentDisposition, mimeType)
+                        fileName.removeSuffix(";")
                     )
                 }
                 val downloadManager = getSystemService(DOWNLOAD_SERVICE) as DownloadManager


### PR DESCRIPTION
Fixes #40 

URLUtils의 정규 표현식이 실제 주어지는 `contentDescription`과 달라서 발생했다. 아래를 보면 끝에 `;`이 없는 것을 볼 수 있다. 일단 단순히 문자열 끝의 세미콜론을 지우는 방식으로 해결했다.

![image](https://user-images.githubusercontent.com/57604817/182075479-afadeb6e-0edb-4f41-be32-200882c874df.png)
